### PR TITLE
Update for VDataTable now no longer in labs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "vue": "^3.2.0",
     "vue-router": "^4.0.0",
     "vue3-apexcharts": "^1.4.4",
-    "vuetify": "^3.3.15",
+    "vuetify": "^3.4.0",
     "webfontloader": "^1.0.0"
   },
   "devDependencies": {

--- a/src/components/CsvToBUFRForm.vue
+++ b/src/components/CsvToBUFRForm.vue
@@ -55,18 +55,18 @@
                                     <v-data-table :items="theData" :headers="headers" class="elevation-1">
                                         <template v-slot:item="{item}">
                                             <tr>
-                                                <td v-for="(value, key) in item.columns" :key="key">
+                                                <td v-for="(value, key) in item" :key="key">
                                                     <v-tooltip
-                                                        v-if="item.columns[key].msg !== ''"
-                                                        :text="item.columns[key].msg">
+                                                        v-if="item[key].msg !== ''"
+                                                        :text="item[key].msg">
                                                         <template v-slot:activator="{ props }">
-                                                            <v-chip :color="item.columns[key].status" v-bind="props">
-                                                                {{item.columns[key].value}}
+                                                            <v-chip :color="item[key].status" v-bind="props">
+                                                                {{item[key].value}}
                                                             </v-chip>
                                                         </template>
                                                     </v-tooltip>
-                                                    <v-chip v-else :color="item.columns[key].status">
-                                                        {{item.columns[key].value}}
+                                                    <v-chip v-else :color="item[key].status">
+                                                        {{item[key].value}}
                                                     </v-chip>
                                                 </td>
                                             </tr>
@@ -249,8 +249,8 @@
     import { VFileInput, VCardActions, VBtn, VCard, VCardText, VCardItem, VChip, VTooltip, VSwitch } from 'vuetify/lib/components/index.mjs';
     import { VList, VListItem, VListSubheader, VSheet, VContainer, VCardTitle, VIcon, VDialog} from 'vuetify/lib/components/index.mjs';
     import { VCardSubtitle} from 'vuetify/lib/components/index.mjs';
-    import { VDataTable} from 'vuetify/lib/labs/VDataTable/index.mjs';
-    import { VStepper, VStepperHeader, VStepperItem, VStepperWindow, VStepperWindowItem, VStepperActions} from 'vuetify/lib/labs/VStepper/index.mjs';
+    import { VDataTable} from 'vuetify/lib/components/index.mjs';
+    import { VStepper, VStepperHeader, VStepperItem, VStepperWindow, VStepperWindowItem, VStepperActions} from 'vuetify/lib/components/index.mjs';
     import InspectBufrButton from '@/components/InspectBufrButton.vue';
     import DownloadButton from '@/components/DownloadButton.vue';
     import TopicHierarchySelector from '@/components/TopicHierarchySelector.vue';

--- a/src/components/InspectBufrButton.vue
+++ b/src/components/InspectBufrButton.vue
@@ -57,7 +57,7 @@
   import {defineComponent, onBeforeMount, onMounted, ref} from "vue";
   import {VCard, VCardTitle, VCardText, VCardItem, VBtn} from "vuetify/lib/components/index.mjs";
   import {VDialog, VContainer, VRow, VCol, VTextField} from "vuetify/lib/components/index.mjs";
-  import { VDataTable } from 'vuetify/lib/labs/VDataTable/index.mjs';
+  import { VDataTable } from 'vuetify/lib/components/index.mjs';
   import LocatorMap from '@/components/LocatorMap.vue';
   // now component to export
   export default defineComponent({

--- a/src/components/StationTable.vue
+++ b/src/components/StationTable.vue
@@ -13,8 +13,8 @@
                 <v-icon size="small" @click="deleteRecord(item)">mdi-delete</v-icon>
               </template>
               <template v-slot:item.url="{ item }">
-                <a :href="item.columns.url">
-                  {{ item.columns.url }}
+                <a :href="item.url">
+                  {{ item.url }}
                 </a>
               </template>
               <template v-slot:top>
@@ -41,7 +41,7 @@
       </v-card>
     </v-col>
   </v-row>
-  
+
 </template>
 
 <script>
@@ -49,7 +49,7 @@ import { defineComponent } from 'vue';
 import { VCard, VCardTitle, VCardText, VChip, VTextField } from 'vuetify/lib/components/index.mjs';
 import { onBeforeMount, onMounted, onBeforeUpdate, onUpdated, onBeforeUnmount, onUnmounted, onErrorCaptured} from 'vue';
 import { ref, computed, watchEffect, watch } from 'vue'
-import { VDataTable } from 'vuetify/lib/labs/VDataTable/index.mjs';
+import { VDataTable } from 'vuetify/lib/components/index.mjs';
 import {useRoute, useRouter} from 'vue-router';
 import APIStatus from '@/components/APIStatus.vue';
 


### PR DESCRIPTION
import { VDataTable} from 'vuetify/lib/components/index.mjs instead of from labs.

Update of items.columns -> item with released version of data table.