### PR TITLE
Removed marker clusters + added custom markers with tooltips

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.1",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.1.0",
+        "@fortawesome/fontawesome-free": "^6.5.2",
         "@mdi/font": "7.0.96",
         "@vue-leaflet/vue-leaflet": "^0.10.1",
         "@vuepic/vue-datepicker": "^5.4.0",
@@ -29,7 +30,7 @@
         "vue-router": "^4.0.0",
         "vue-tel-input": "^8.3.1",
         "vue3-apexcharts": "^1.4.4",
-        "vuetify": "^3.4.0-beta.1",
+        "vuetify": "^3.4.0",
         "webfontloader": "^1.0.0"
       },
       "devDependencies": {
@@ -474,6 +475,15 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.5.2.tgz",
+      "integrity": "sha512-hRILoInAx8GNT5IMkrtIt9blOdrqHOnPBH+k70aWUAqPZPgopb9G5EQJFpaBx/S8zp2fC+mPW349Bziuk1o28Q==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -3000,9 +3010,9 @@
       "integrity": "sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg=="
     },
     "node_modules/vite": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
-      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.3.tgz",
+      "integrity": "sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==",
       "devOptional": true,
       "dependencies": {
         "esbuild": "^0.18.10",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.1.0",
+    "@fortawesome/fontawesome-free": "^6.5.2",
     "@mdi/font": "7.0.96",
     "@vue-leaflet/vue-leaflet": "^0.10.1",
     "@vuepic/vue-datepicker": "^5.4.0",

--- a/src/components/DatasetEditorForm.vue
+++ b/src/components/DatasetEditorForm.vue
@@ -559,7 +559,7 @@
                         <br>
                         <p><b>Email:</b> The email address of the contact.</p>
                         <br>
-                        <p><b>Phone Number:</b> The phone number of the contact, written in
+                        <p><b>Phone Number (optional):</b> The phone number of the contact, written in
                             international
                             format (+).</p>
                     </v-card-text>
@@ -1766,9 +1766,6 @@ export default defineComponent({
                 name: form.host.individual,
                 position: form.host.positionName,
                 organization: form.host.name,
-                phones: [{
-                    value: removeSpacesFrom(form.host.phone)
-                }],
                 emails: [{
                     value: form.host.email
                 }],
@@ -1788,6 +1785,13 @@ export default defineComponent({
                 contactInstructions: form.host.contactInstructions,
                 roles: ["host"]
             };
+
+            // Add optional phone number if it exists
+            if (form.host.phone) {
+                hostDetails.phones = [];
+                hostDetails.phones.push({ value: removeSpacesFrom(form.host.phone) });
+            }
+
             schemaModel.properties.contacts.push(hostDetails);
 
             const currentDTNoMilliseconds = new Date().toISOString().slice(0, -5) + "Z";

--- a/src/components/DatasetEditorForm.vue
+++ b/src/components/DatasetEditorForm.vue
@@ -451,8 +451,10 @@
                         <br>
                         <p><b>Description:</b> A free-text summary description of the dataset.</p>
                         <br>
-                        <p><b>Identifier:</b> The unique identifier for the dataset. It should start with <b>urn:wmo:md</b></p>
-                        <p><i>Note: once the dataset is created, the identifier can no longer be updated. To use a different Identifier you will need to delete and create the dataset.</i></p>
+                        <p><b>Identifier:</b> The unique identifier for the dataset. It should start with
+                            <b>urn:wmo:md</b></p>
+                        <p><i>Note: once the dataset is created, the identifier can no longer be updated. To use a
+                                different Identifier you will need to delete and create the dataset.</i></p>
                         <br>
                         <p><b>Centre ID:</b> This is pre-filled and <i>cannot be edited</i>.</p>
                         <br>
@@ -1810,14 +1812,14 @@ export default defineComponent({
         const validateForm = async () => {
             const { valid } = await formRef.value.validate();
 
-            if (valid && isHostPhoneValid.value) {
-                message.value = "Form is valid, please proceed."
-                formValidated.value = true;
-            }
-            else {
-                message.value = "Form is invalid, please check all of the fields are filled correctly and try again."
-                formValidated.value = false;
-            }
+            const isFormValid = valid && (!model.value.host.phone || isHostPhoneValid.value);
+
+            message.value = isFormValid
+                ? "Form is valid, please proceed."
+                : "Form is invalid, please check all of the fields are filled correctly and try again.";
+
+            formValidated.value = isFormValid;
+
             openValidationDialog.value = true;
         };
 

--- a/src/components/StationMap.vue
+++ b/src/components/StationMap.vue
@@ -10,11 +10,10 @@ import { defineComponent, ref, computed, onMounted, watch } from 'vue';
 import { VCard } from 'vuetify/lib/components/index.mjs';
 
 // Leaflet imports
-import 'leaflet/dist/leaflet.css';
-import 'leaflet.markercluster/dist/MarkerCluster.css';
-import 'leaflet.markercluster/dist/MarkerCluster.Default.css';
 import L from 'leaflet';
-import 'leaflet.markercluster';
+import 'leaflet/dist/leaflet.css';
+import '@fortawesome/fontawesome-free/css/all.css';
+
 
 export default defineComponent({
     name: "StationMap",
@@ -49,14 +48,24 @@ export default defineComponent({
         const map = ref(null);
         const stationLayer = ref(null);
 
+        // Computed
+
+        // Ensure all necessary data is available before updating the map
+        const readyToUpdate = computed(() => {
+            return map.value && stationLayer.value && props.messages.length > 0;
+        });
+
         // Create geoJSON data from the messages prop
         const features = computed(() => {
+            if (props.messages.length === 0) {
+                return [];
+            }
             return props.messages.map(msg => {
                 return {
                     type: 'Feature',
                     id: msg.id,
                     properties: {
-                        wigos_station_identifer: msg.wsi
+                        wigos_station_identifier: msg.wsi
                     },
                     geometry: {
                         type: 'Point',
@@ -66,29 +75,49 @@ export default defineComponent({
             })
         });
 
+        // Count the number of messages published by each WSI
+        const wsiCount = computed(() => {
+            const counts = {};
+            props.messages.forEach(msg => {
+                if (counts[msg.wsi]) {
+                    counts[msg.wsi] += 1;
+                } else {
+                    counts[msg.wsi] = 1;
+                }
+            });
+            return counts;
+        });
+
         // Fill map with markers when data changes
         const updateMarkers = () => {
-            if (map.value && props.messages.length > 0) {
+            if (readyToUpdate.value) {
                 stationLayer.value.clearLayers();
-                // Instantiate LatLngBounds object
-                var bounds = L.latLngBounds()
-                // Structure features array in form [lat, lon]
-                // required for markers
-                features.value.map((feature) => {
+                // Initialise LatLngBounds object
+                let bounds = L.latLngBounds()
+                // Structure features array in form [lat, lon] required for markers
+                features.value.forEach((feature) => {
                     let coords = feature.geometry?.coordinates;
                     // Check if coordinates are defined before proceeding
                     if (coords) {
                         // Swap coordinates to [lat, lon] for Leaflet
                         coords = [feature.geometry.coordinates[1], feature.geometry.coordinates[0]];
-                        const marker = L.marker(coords, {
-                            // Set the marker icon, if desired
-                            icon: L.icon({
-                                iconUrl: import.meta.env.VITE_BASE_URL + '/assets/marker-icon.png',
-                                shadowUrl: import.meta.env.VITE_BASE_URL + '/assets/marker-shadow.png',
-                                iconSize: [25, 41],
-                                iconAnchor: [12, 41],
-                                popupAnchor: [1, -34]
+                        // Define marker styling
+                        const iconHtml = "<i class='fas fa-location-dot' style='color: #003DA5; font-size: 24px; filter: drop-shadow(2px 2px 0.5px rgba(0,0,0,0.4));'/>"
+                        let marker = L.marker(coords, {
+                            icon: L.divIcon({
+                                html: iconHtml,
+                                className: 'customIcon',
+                                iconSize: L.point(30, 30)  // Set size sufficiently large to handle icon
                             })
+                        });
+                        // Bind a tooltip to each marker to display the WSI
+                        marker.bindTooltip(
+                            `WSI: ${feature.properties.wigos_station_identifier}<br>
+                            Messages: ${wsiCount.value[feature.properties.wigos_station_identifier]}`, {
+                            permanent: false,
+                            direction: 'top',
+                            // Offset tooltip to avoid covering marker
+                            offset: [-5, -15]
                         });
                         // Set ID for marker, which is a link to
                         // the notification
@@ -96,8 +125,8 @@ export default defineComponent({
                         // Set type of marker
                         marker.type = "host";
                         // Extend LatLngBounds with coordinates
-                        bounds.extend(coords)
                         stationLayer.value.addLayer(marker);
+                        bounds.extend(coords)
                     }
                 })
                 map.value.fitBounds(bounds);
@@ -105,26 +134,26 @@ export default defineComponent({
         };
 
         onMounted(() => {
+            // Create the map, base layer and add it to the DOM
             map.value = L.map(props.id, { zoomAnimation: false, fadeAnimation: true, markerZoomAnimation: true }).setView(props.center, props.zoom);
             map.value.attributionControl.setPrefix('');
             L.tileLayer(`${import.meta.env.VITE_BASEMAP_URL}`, { attribution: `${import.meta.env.VITE_BASEMAP_ATTRIBUTION}` }).addTo(map.value);
-            // Disable the spiderfy and zoom effects
-            let clusters = new L.markerClusterGroup({
-                spiderfyOnMaxZoom: false,
-                showCoverageOnHover: false,
-                // Clicking on a cluster zooms in to show more clusters
-                zoomToBoundsOnClick: true,
-                // Shows a marker as a size 1 cluster
-                singleMarkerMode: true
-            });
-            clusters.addTo(map.value);
-            stationLayer.value = clusters;
-            // Update markers then cluster
+            // Initialise the station layer and update with markers
+            stationLayer.value = L.layerGroup().addTo(map.value);
             updateMarkers();
         })
 
         watch(features, () => { updateMarkers() });
     }
 })
-
 </script>
+
+<style scoped>
+.customIcon {
+    /* Ensures the text icon is centered both vertically and horizontally */
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+}
+</style>

--- a/src/components/StationMap.vue
+++ b/src/components/StationMap.vue
@@ -75,14 +75,17 @@ export default defineComponent({
             })
         });
 
-        // Count the number of messages published by each WSI
-        const wsiCount = computed(() => {
+        // Count the number of messages published by each WSI at each location
+        const wsiCoordCount = computed(() => {
             const counts = {};
             props.messages.forEach(msg => {
-                if (counts[msg.wsi]) {
-                    counts[msg.wsi] += 1;
+                // The key is not just determined by WSI, but also by the coordinates
+                // Note: This helps in the example of moving stations e.g. buoys
+                let key = `${msg.wsi}_${msg.coordinates[1]}_${msg.coordinates[0]}`
+                if (counts[key]) {
+                    counts[key]++;
                 } else {
-                    counts[msg.wsi] = 1;
+                    counts[key] = 1;
                 }
             });
             return counts;
@@ -110,10 +113,12 @@ export default defineComponent({
                                 iconSize: L.point(30, 30)  // Set size sufficiently large to handle icon
                             })
                         });
+                        // Define marker key (WSI, lat, lon)
+                        let key = `${feature.properties.wigos_station_identifier}_${coords[0]}_${coords[1]}`
                         // Bind a tooltip to each marker to display the WSI
                         marker.bindTooltip(
                             `WSI: ${feature.properties.wigos_station_identifier}<br>
-                            Messages: ${wsiCount.value[feature.properties.wigos_station_identifier]}`, {
+                            Messages: ${wsiCoordCount.value[key]}`, {
                             permanent: false,
                             direction: 'top',
                             // Offset tooltip to avoid covering marker

--- a/src/components/StationMap.vue
+++ b/src/components/StationMap.vue
@@ -93,49 +93,51 @@ export default defineComponent({
 
         // Fill map with markers when data changes
         const updateMarkers = () => {
-            if (readyToUpdate.value) {
-                stationLayer.value.clearLayers();
-                // Initialise LatLngBounds object
-                let bounds = L.latLngBounds()
-                // Structure features array in form [lat, lon] required for markers
-                features.value.forEach((feature) => {
-                    let coords = feature.geometry?.coordinates;
-                    // Check if coordinates are defined before proceeding
-                    if (coords) {
-                        // Swap coordinates to [lat, lon] for Leaflet
-                        coords = [feature.geometry.coordinates[1], feature.geometry.coordinates[0]];
-                        // Define marker styling
-                        const iconHtml = "<i class='fas fa-location-dot' style='color: #003DA5; font-size: 24px; filter: drop-shadow(2px 2px 0.5px rgba(0,0,0,0.4));'/>"
-                        let marker = L.marker(coords, {
-                            icon: L.divIcon({
-                                html: iconHtml,
-                                className: 'customIcon',
-                                iconSize: L.point(30, 30)  // Set size sufficiently large to handle icon
-                            })
-                        });
-                        // Define marker key (WSI, lat, lon)
-                        let key = `${feature.properties.wigos_station_identifier}_${coords[0]}_${coords[1]}`
-                        // Bind a tooltip to each marker to display the WSI
-                        marker.bindTooltip(
-                            `WSI: ${feature.properties.wigos_station_identifier}<br>
-                            Messages: ${wsiCoordCount.value[key]}`, {
-                            permanent: false,
-                            direction: 'top',
-                            // Offset tooltip to avoid covering marker
-                            offset: [-5, -15]
-                        });
-                        // Set ID for marker, which is a link to
-                        // the notification
-                        marker.id = feature.id;
-                        // Set type of marker
-                        marker.type = "host";
-                        // Extend LatLngBounds with coordinates
-                        stationLayer.value.addLayer(marker);
-                        bounds.extend(coords)
-                    }
-                })
-                map.value.fitBounds(bounds);
-            }
+            if (!readyToUpdate.value) return;
+
+            // Clear existing markers first
+            stationLayer.value.clearLayers();
+            // Initialise LatLngBounds object
+            let bounds = L.latLngBounds()
+            // Structure features array in form [lat, lon] required for markers
+            features.value.forEach((feature) => {
+                let coords = feature.geometry?.coordinates;
+
+                // Check if coordinates are defined before proceeding
+                if (!coords) return;
+
+                // Swap coordinates to [lat, lon] for Leaflet
+                coords = [feature.geometry.coordinates[1], feature.geometry.coordinates[0]];
+                // Define marker styling
+                const iconHtml = "<i class='fas fa-location-dot' style='color: #003DA5; font-size: 24px; filter: drop-shadow(2px 2px 0.5px rgba(0,0,0,0.4));'/>"
+                let marker = L.marker(coords, {
+                    icon: L.divIcon({
+                        html: iconHtml,
+                        className: 'customIcon',
+                        iconSize: L.point(30, 30)  // Set size sufficiently large to handle icon
+                    })
+                });
+                // Define marker key (WSI, lat, lon)
+                let key = `${feature.properties.wigos_station_identifier}_${coords[0]}_${coords[1]}`
+                // Bind a tooltip to each marker to display the WSI
+                marker.bindTooltip(
+                    `WSI: ${feature.properties.wigos_station_identifier}<br>
+                    Messages: ${wsiCoordCount.value[key]}`, {
+                    permanent: false,
+                    direction: 'top',
+                    // Offset tooltip to avoid covering marker
+                    offset: [-5, -15]
+                });
+                // Set ID for marker, which is a link to
+                // the notification
+                marker.id = feature.id;
+                // Set type of marker
+                marker.type = "host";
+                // Extend LatLngBounds with coordinates
+                stationLayer.value.addLayer(marker);
+                bounds.extend(coords)
+            })
+            map.value.fitBounds(bounds);
         };
 
         onMounted(() => {

--- a/src/components/StationTable.vue
+++ b/src/components/StationTable.vue
@@ -45,11 +45,8 @@
 </template>
 
 <script>
-import { defineComponent } from 'vue';
-import { VCard, VCardTitle, VCardText, VTextField } from 'vuetify/lib/components/index.mjs';
-import { onMounted } from 'vue';
-import { ref } from 'vue'
-import { VDataTable } from 'vuetify/lib/components/index.mjs';
+import { defineComponent, ref, onMounted } from 'vue';
+import { VCard, VCardTitle, VCardText, VTextField, VDataTable } from 'vuetify/lib/components/index.mjs';
 import { useRouter } from 'vue-router';
 import APIStatus from '@/components/APIStatus.vue';
 
@@ -80,11 +77,11 @@ export default defineComponent({
         items.value = null;
         const apiURL = `${import.meta.env.VITE_API_URL}/collections/stations/items?f=json`;
         try {
-          var response = await fetch(apiURL);
+          let response = await fetch(apiURL);
           if (!response.ok) {
             throw new Error(`HTTP error! Status: ${response.status}`);
           }else{
-            var featureCollection = await response.json();
+            let featureCollection = await response.json();
             items.value = featureCollection.features.map( (feature) => {
               return{
                 actions: "actions",
@@ -136,7 +133,7 @@ export default defineComponent({
       if( selectedStation.value === stationToDelete.value ){
         const apiURL = `${import.meta.env.VITE_API_URL}/collections/stations/items/${stationToDelete.value}`;
         try{
-          var response = await fetch(apiURL, {
+          let response = await fetch(apiURL, {
               method: 'DELETE',
               headers: {
                   'encode': 'json',

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -19,14 +19,14 @@ import 'vue-tel-input/vue-tel-input.css';
 const globalOptions = {
   mode: 'international',
   autoFormat: true,
-  defaultCountry: 'US',
   validCharactersOnly: true,
   dropdownOptions: {
     showSearchBox: true
   },
   inputOptions: {
-    showDialCode: true,
-    required: true
+    required: false,
+    placeholder: 'Phone number (optional)',
+    autocomplete: 'off',
   },
 }
 


### PR DESCRIPTION
The clustered markers seem to cause more problems than they solve, so I've removed them altogether. There are now:

- No clusters, instead each station has its own marker that has been given custom styling.
- Hovering over such a marker displays a tooltip, containing the associated WSI and message count.