### PR TITLE
don't use "Campbell" in plugin display name

### DIFF
--- a/public/plugins/plugin-list.json
+++ b/public/plugins/plugin-list.json
@@ -43,8 +43,8 @@
     }
   ],
   "templates": [
-    { "title": "Campbell", "id": "CampbellAfrica-v1-template" },
-    { "title": "AWS", "id": "aws-template" }
+    { "title": "AWS", "id": "aws-template" },
+    { "title": "WIS2-pilot-template-2012", "id": "CampbellAfrica-v1-template" }
   ],
   "buckets": [
     { "title": "Incoming", "id": "wis2box-incoming" },

--- a/public/plugins/plugin-list.json
+++ b/public/plugins/plugin-list.json
@@ -44,7 +44,7 @@
   ],
   "templates": [
     { "title": "AWS", "id": "aws-template" },
-    { "title": "WIS2-pilot-template-2012", "id": "CampbellAfrica-v1-template" }
+    { "title": "WIS2-pilot-template-2021", "id": "CampbellAfrica-v1-template" }
   ],
   "buckets": [
     { "title": "Incoming", "id": "wis2box-incoming" },


### PR DESCRIPTION
We had agrreed to no use "Campbell" in plugin display name