### PR TITLE
Bounding box coordinates type fix + improved API response handling

### DIFF
--- a/src/components/DatasetEditorForm.vue
+++ b/src/components/DatasetEditorForm.vue
@@ -1982,9 +1982,15 @@ export default defineComponent({
                 // is success, display a success message
                 if (response.status === OK && responseData.status === "success") {
                     message.value = "Dataset removed successfully.";
-                    // Open the success window to show this message clearly
-                    openSuccessDialog.value = true;
                 }
+
+                // Otherwise, there must be an application-level error in the API
+                else {
+                    message.value = responseData.status;
+                }
+
+                // Open the success window to show this message clearly
+                openSuccessDialog.value = true;
             }
             catch (error) {
                 console.error(error);
@@ -2025,9 +2031,15 @@ export default defineComponent({
                 // is success, display a success message
                 if (response.status === OK && responseData.status === "success") {
                     message.value = isNew.value ? "Dataset added successfully!" : "Dataset updated successfully!";
-                    // Open the success window to show this message clearly
-                    openSuccessDialog.value = true;
                 }
+                
+                // Otherwise, there must be an application-level error in the API
+                else {
+                    message.value = responseData.status;
+                }
+
+                // Open the success window to show this message clearly
+                openSuccessDialog.value = true;
             }
             catch (error) {
                 console.log(error);

--- a/src/components/DatasetEditorForm.vue
+++ b/src/components/DatasetEditorForm.vue
@@ -237,7 +237,7 @@
                                 <v-col cols="4" />
                                 <v-col cols="4">
                                     <v-text-field label="North Latitude" type="number"
-                                        v-model="model.extents.northLatitude" :rules="[rules.required, rules.latitude]"
+                                        v-model.number="model.extents.northLatitude" :rules="[rules.required, rules.latitude]"
                                         variant="outlined" clearable></v-text-field>
                                 </v-col>
                                 <v-col cols="4" />
@@ -245,13 +245,13 @@
                             <v-row class="coordinate-rows">
                                 <v-col cols="4">
                                     <v-text-field label="West Longitude" type="number"
-                                        v-model="model.extents.westLongitude" :rules="[rules.required, rules.longitude]"
+                                        v-model.number="model.extents.westLongitude" :rules="[rules.required, rules.longitude]"
                                         variant="outlined" clearable></v-text-field>
                                 </v-col>
                                 <v-col cols="4" />
                                 <v-col cols="4">
                                     <v-text-field label="East Longitude" type="number"
-                                        v-model="model.extents.eastLongitude" :rules="[rules.required, rules.longitude]"
+                                        v-model.number="model.extents.eastLongitude" :rules="[rules.required, rules.longitude]"
                                         variant="outlined" clearable></v-text-field>
                                 </v-col>
                             </v-row>
@@ -259,7 +259,7 @@
                                 <v-col cols="4" />
                                 <v-col cols="4">
                                     <v-text-field label="South Latitude" type="number"
-                                        v-model="model.extents.southLatitude" :rules="[rules.required, rules.latitude]"
+                                        v-model.number="model.extents.southLatitude" :rules="[rules.required, rules.latitude]"
                                         variant="outlined" clearable></v-text-field>
                                 </v-col>
                                 <v-col cols="4" />

--- a/src/components/DatasetEditorForm.vue
+++ b/src/components/DatasetEditorForm.vue
@@ -2035,7 +2035,7 @@ export default defineComponent({
                 
                 // Otherwise, there must be an application-level error in the API
                 else {
-                    message.value = responseData.status;
+                    message.value = responseData.status || "Error submitting data, please check the console for details.";
                 }
 
                 // Open the success window to show this message clearly


### PR DESCRIPTION
**Summary:**
- The bounding box coordinates were given via a `v-text-field`. The problem is, even when the `type` is set to `Number`, this only restricts the type of input; the output is still always a string. This has been fixed by using `v-model.number` instead of `v-model`, which now returns floats (this has been tested).
- When submitting or removing a dataset, sometimes the API response will be okay but the status is not `success`. This case is now handled and the response is displayed to the user.