### PR TITLE
fix: prevent existing plugins displaying default values in the dialogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,18 @@ cd wis2box-webapp
 
 ### 2. Set the environment variables
 
-Create a file in the root directory named `.env`. Here you can set all of the necessary environment variables to be used. For testing purposes, the most important two are `WIS2BOX_BASEMAP_URL` and `WIS2BOX_BASEMAP_ATTRIBUTION`, for example:
+Create a file in the root directory named `.env`. Here you can set all of the necessary environment variables to be used.
+
+In a local environment, the environment variables have prefix `VITE_`. For example, `VITE_API_URL`. If testing locally, here are the most important environment variables to set:
 
 ```bash
-WIS2BOX_BASEMAP_URL=https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png
-WIS2BOX_BASEMAP_ATTRIBUTION=<a href="https://osm.org/copyright">OpenStreetMap</a> contributors
+VITE_API_URL=http://localhost:8080/oapi
+VITE_BASE_URL=http://localhost:8080/wis2box-webapp
+VITE_BASEMAP_URL=https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png
+VITE_BASEMAP_ATTRIBUTION=<a href="https://osm.org/copyright">OpenStreetMap</a> contributors
 ```
 
-You can find an exhaustive list <a href="https://github.com/wmo-im/wis2box-webapp/blob/main/tests/test.env">here</a>.
+In a Docker environment, the environment variables have prefix `WIS2BOX_`. We recommend that you copy these from the test environment file, found <a href="https://github.com/wmo-im/wis2box-webapp/blob/main/tests/test.env">here</a>.
 
 Now we are ready to start the web app with or without Docker.
 

--- a/src/components/DatasetEditorForm.vue
+++ b/src/components/DatasetEditorForm.vue
@@ -644,7 +644,7 @@
                         {{ message }}
                     </v-card-text>
                     <v-card-actions>
-                        <v-btn block @click="resetMessage('validation')" :color="formValidated ? '#64BF40' : 'error'">
+                        <v-btn block variant="flat" @click="resetMessage('validation')" :color="formValidated ? '#64BF40' : 'error'">
                             OK
                         </v-btn>
                     </v-card-actions>
@@ -2108,7 +2108,7 @@ export default defineComponent({
 
         // For each plugin name, auto populate the plugin fields
         watch(() => pluginName.value, () => {
-            if (pluginName.value) {
+            if (pluginName.value && pluginIsNew.value) {
                 defaultPluginFields(pluginName.value);
             }
         });

--- a/src/components/DatasetEditorForm.vue
+++ b/src/components/DatasetEditorForm.vue
@@ -714,8 +714,9 @@
                         <v-col cols="12">
                             <v-row>
                                 <v-col cols="8">
+                                    <!-- Disable this if editing an existing plugin -->
                                     <v-select label="Plugin Name" v-model="pluginName" :items="pluginList"
-                                        item-title="title" item-value="id" variant="outlined"></v-select>
+                                        item-title="title" item-value="id" variant="outlined" :disabled="!pluginIsNew"></v-select>
                                 </v-col>
                                 <v-col cols="4">
                                     <v-text-field label="File Extension" v-model="pluginFileExtension"


### PR DESCRIPTION
Fixes #53.

**Changes**
- The plugin details use default values _only if_ a new plugin is being created.
- The 'Plugin Name' drop down is now disabled when configuring existing plugins.
- Updated the 'Environment Variables' section of the documentation to support users who are testing locally, as without Docker the environment variables have prefix `VITE_`, not `WIS2BOX_`.