### PR TITLE
Issue#787

### DIFF
--- a/src/components/DatasetEditorForm.vue
+++ b/src/components/DatasetEditorForm.vue
@@ -1221,7 +1221,7 @@ export default defineComponent({
             // Properties information
             formModel.identification.title = schema.properties.title;
             formModel.identification.description = schema.properties.description;
-            formModel.identification.language = schema.properties.language;
+            formModel.identification.language = {code: schema.properties.language};
             formModel.identification.keywords = schema.properties.keywords;
 
             // Themes - hardcoded for now
@@ -1782,7 +1782,7 @@ export default defineComponent({
             schemaModel.properties.identifier = form.identification.identifier;
             schemaModel.properties.title = form.identification.title;
             schemaModel.properties.description = form.identification.description;
-            schemaModel.properties.language = null;
+            schemaModel.properties.language = {code: null};
             schemaModel.properties.keywords = form.identification.keywords;
             // Themes
             const concepts = form.identification.concepts.map(item => ({ id: item, title: getTitleOf(item) }));

--- a/src/components/DatasetEditorForm.vue
+++ b/src/components/DatasetEditorForm.vue
@@ -933,14 +933,14 @@ export default defineComponent({
         const openMessageDialog = ref(false);
 
         const copyIdentifier = () => {
-            const identifier = model.value.identification.identifier; // 获取当前 identifier
+            const identifier = model.value.identification.identifier; // acquire identifier
             navigator.clipboard.writeText(identifier).then(() => {
-                message.value = "Identifier copied to clipboard!"; // 成功提示
-                openMessageDialog.value = true; // 打开消息对话框
+                message.value = "Identifier copied to clipboard!"; // success message
+                openMessageDialog.value = true; // open message dialog
             }).catch(err => {
-                console.error('Error copying text: ', err); // 错误处理
-                message.value = "Failed to copy identifier."; // 失败提示
-                openMessageDialog.value = true; // 打开消息对话框
+                console.error('Error copying text: ', err); // error handling
+                message.value = "Failed to copy identifier."; // fail message
+                openMessageDialog.value = true; // open message dialog
             });
         };
 
@@ -1240,7 +1240,7 @@ export default defineComponent({
             // Properties information
             formModel.identification.title = schema.properties.title;
             formModel.identification.description = schema.properties.description;
-            formModel.identification.language = {code: schema.properties.language};
+            formModel.identification.language = schema.properties.language;
             formModel.identification.keywords = schema.properties.keywords;
 
             // Themes - hardcoded for now
@@ -1801,7 +1801,7 @@ export default defineComponent({
             schemaModel.properties.identifier = form.identification.identifier;
             schemaModel.properties.title = form.identification.title;
             schemaModel.properties.description = form.identification.description;
-            schemaModel.properties.language = {code: null};
+            schemaModel.properties.language = null;
             schemaModel.properties.keywords = form.identification.keywords;
             // Themes
             const concepts = form.identification.concepts.map(item => ({ id: item, title: getTitleOf(item) }));
@@ -2272,3 +2272,4 @@ export default defineComponent({
     vertical-align: middle;
 }
 </style>
+

--- a/src/components/DatasetEditorForm.vue
+++ b/src/components/DatasetEditorForm.vue
@@ -113,11 +113,17 @@
                                 </v-col>
                             </v-row>
                             <v-row dense>
-                                <v-col cols="12">
+                                <v-col cols="11">
                                     <v-text-field label="Identifier" type="string"
                                         v-model="model.identification.identifier"
-                                        :rules="[rules.required, rules.identifier]" variant="outlined" clearable
-                                        :disabled="!isNew"></v-text-field>
+                                        readonly variant="outlined">
+                                    </v-text-field>
+                                </v-col>
+                                <v-col cols="1">    
+                                    <v-btn icon @click="copyIdentifier" 
+                                    aria-label="Copy Identifier">
+                                    <v-icon>mdi-content-copy</v-icon>
+                                    </v-btn>
                                 </v-col>
                             </v-row>
                         </v-col>
@@ -925,6 +931,19 @@ export default defineComponent({
 
         // Message dialog windows
         const openMessageDialog = ref(false);
+
+        const copyIdentifier = () => {
+            const identifier = model.value.identification.identifier; // 获取当前 identifier
+            navigator.clipboard.writeText(identifier).then(() => {
+                message.value = "Identifier copied to clipboard!"; // 成功提示
+                openMessageDialog.value = true; // 打开消息对话框
+            }).catch(err => {
+                console.error('Error copying text: ', err); // 错误处理
+                message.value = "Failed to copy identifier."; // 失败提示
+                openMessageDialog.value = true; // 打开消息对话框
+            });
+        };
+
         const openValidationDialog = ref(false);
         const openSuccessDialog = ref(false);
 
@@ -2228,7 +2247,8 @@ export default defineComponent({
             resetMessage,
             redirectUser,
             verifyFormIsFilled,
-            submitMetadata
+            submitMetadata,
+            copyIdentifier
         }
     }
 });

--- a/src/components/DatasetEditorForm.vue
+++ b/src/components/DatasetEditorForm.vue
@@ -2272,4 +2272,3 @@ export default defineComponent({
     vertical-align: middle;
 }
 </style>
-


### PR DESCRIPTION
Allow for WCMP2 id to be copyable in webapp:

For "identifier", make it "readonly", user cannot modify it but can copy it by selecting them and "Ctrl+C/Ctrl+V" or use the clickable button on the right hand:

<img width="711" alt="image" src="https://github.com/user-attachments/assets/96bf14d3-7f09-4494-969f-757a0908c319">
<img width="1020" alt="image" src="https://github.com/user-attachments/assets/2e9fa158-0a72-4a8a-8be5-0f00a53a882a">

