### PR TITLE
Issue#785

### DIFF
--- a/src/components/DatasetEditorForm.vue
+++ b/src/components/DatasetEditorForm.vue
@@ -1221,7 +1221,7 @@ export default defineComponent({
             // Properties information
             formModel.identification.title = schema.properties.title;
             formModel.identification.description = schema.properties.description;
-            formModel.identification.language = schema.properties.language;
+            formModel.identification.language = {code: schema.properties.language};
             formModel.identification.keywords = schema.properties.keywords;
 
             // Themes - hardcoded for now
@@ -1782,7 +1782,7 @@ export default defineComponent({
             schemaModel.properties.identifier = form.identification.identifier;
             schemaModel.properties.title = form.identification.title;
             schemaModel.properties.description = form.identification.description;
-            schemaModel.properties.language = null;
+            schemaModel.properties.language = {code: null};
             schemaModel.properties.keywords = form.identification.keywords;
             // Themes
             const concepts = form.identification.concepts.map(item => ({ id: item, title: getTitleOf(item) }));

--- a/src/components/DatasetEditorForm.vue
+++ b/src/components/DatasetEditorForm.vue
@@ -113,11 +113,17 @@
                                 </v-col>
                             </v-row>
                             <v-row dense>
-                                <v-col cols="12">
+                                <v-col cols="11">
                                     <v-text-field label="Identifier" type="string"
                                         v-model="model.identification.identifier"
-                                        :rules="[rules.required, rules.identifier]" variant="outlined" clearable
-                                        :disabled="!isNew"></v-text-field>
+                                        readonly variant="outlined">
+                                    </v-text-field>
+                                </v-col>
+                                <v-col cols="1">    
+                                    <v-btn icon @click="copyIdentifier" 
+                                    aria-label="Copy Identifier">
+                                    <v-icon>mdi-content-copy</v-icon>
+                                    </v-btn>
                                 </v-col>
                             </v-row>
                         </v-col>
@@ -925,6 +931,19 @@ export default defineComponent({
 
         // Message dialog windows
         const openMessageDialog = ref(false);
+
+        const copyIdentifier = () => {
+            const identifier = model.value.identification.identifier; // 获取当前 identifier
+            navigator.clipboard.writeText(identifier).then(() => {
+                message.value = "Identifier copied to clipboard!"; // 成功提示
+                openMessageDialog.value = true; // 打开消息对话框
+            }).catch(err => {
+                console.error('Error copying text: ', err); // 错误处理
+                message.value = "Failed to copy identifier."; // 失败提示
+                openMessageDialog.value = true; // 打开消息对话框
+            });
+        };
+
         const openValidationDialog = ref(false);
         const openSuccessDialog = ref(false);
 
@@ -2228,7 +2247,8 @@ export default defineComponent({
             resetMessage,
             redirectUser,
             verifyFormIsFilled,
-            submitMetadata
+            submitMetadata,
+            copyIdentifier
         }
     }
 });

--- a/src/components/DatasetEditorForm.vue
+++ b/src/components/DatasetEditorForm.vue
@@ -113,17 +113,11 @@
                                 </v-col>
                             </v-row>
                             <v-row dense>
-                                <v-col cols="11">
+                                <v-col cols="12">
                                     <v-text-field label="Identifier" type="string"
                                         v-model="model.identification.identifier"
-                                        readonly variant="outlined">
-                                    </v-text-field>
-                                </v-col>
-                                <v-col cols="1">    
-                                    <v-btn icon @click="copyIdentifier" 
-                                    aria-label="Copy Identifier">
-                                    <v-icon>mdi-content-copy</v-icon>
-                                    </v-btn>
+                                        :rules="[rules.required, rules.identifier]" variant="outlined" clearable
+                                        :disabled="!isNew"></v-text-field>
                                 </v-col>
                             </v-row>
                         </v-col>
@@ -931,19 +925,6 @@ export default defineComponent({
 
         // Message dialog windows
         const openMessageDialog = ref(false);
-
-        const copyIdentifier = () => {
-            const identifier = model.value.identification.identifier; // 获取当前 identifier
-            navigator.clipboard.writeText(identifier).then(() => {
-                message.value = "Identifier copied to clipboard!"; // 成功提示
-                openMessageDialog.value = true; // 打开消息对话框
-            }).catch(err => {
-                console.error('Error copying text: ', err); // 错误处理
-                message.value = "Failed to copy identifier."; // 失败提示
-                openMessageDialog.value = true; // 打开消息对话框
-            });
-        };
-
         const openValidationDialog = ref(false);
         const openSuccessDialog = ref(false);
 
@@ -1240,7 +1221,7 @@ export default defineComponent({
             // Properties information
             formModel.identification.title = schema.properties.title;
             formModel.identification.description = schema.properties.description;
-            formModel.identification.language = {code: schema.properties.language};
+            formModel.identification.language = schema.properties.language;
             formModel.identification.keywords = schema.properties.keywords;
 
             // Themes - hardcoded for now
@@ -1801,7 +1782,7 @@ export default defineComponent({
             schemaModel.properties.identifier = form.identification.identifier;
             schemaModel.properties.title = form.identification.title;
             schemaModel.properties.description = form.identification.description;
-            schemaModel.properties.language = {code: null};
+            schemaModel.properties.language = null;
             schemaModel.properties.keywords = form.identification.keywords;
             // Themes
             const concepts = form.identification.concepts.map(item => ({ id: item, title: getTitleOf(item) }));
@@ -2247,8 +2228,7 @@ export default defineComponent({
             resetMessage,
             redirectUser,
             verifyFormIsFilled,
-            submitMetadata,
-            copyIdentifier
+            submitMetadata
         }
     }
 });

--- a/src/components/stations/ImportOSCAR.vue
+++ b/src/components/stations/ImportOSCAR.vue
@@ -31,7 +31,7 @@
       <v-card-item>
         <v-form>
           <v-text-field :rules="[rules.validWSI]" v-model="wsi" label="WIGOS Station Identifier"
-            hint="Enter WIGOS Station Identifier" persistent-hint />
+            hint="Enter WIGOS Station Identifier" persistent-hint @blur="trimWSI"/>
           <v-card-actions align="center">
             <v-btn @click="submit">Search</v-btn>
           </v-card-actions>
@@ -148,6 +148,9 @@ export default defineComponent({
   setup() {
     const wsi = ref("");
     // this needs to be moved to a class / pinia model.
+    const trimWSI = () => {
+      wsi.value = wsi.value.trim();
+    };
     const station = ref({
       id: null,  // WSI
       type: 'Feature',
@@ -400,7 +403,8 @@ export default defineComponent({
       showRedirect,
       submit,
       token,
-      selectedDataset
+      selectedDataset,
+      trimWSI
     };
   }
 });


### PR DESCRIPTION
Add blanket functions to trim leading/trailing spaces from form elements

Add "trim" func to deal with leading/trailing spaces when user want to tape "WIGOS Station Identifier" and click search:
take "    0-20000-0-54511     " as an example:
<img width="682" alt="image" src="https://github.com/user-attachments/assets/c0160b38-1ace-4b48-961b-e54eec005066">
<img width="840" alt="image" src="https://github.com/user-attachments/assets/259f8c69-90d4-47fa-bf68-29fff728b416">
<img width="941" alt="image" src="https://github.com/user-attachments/assets/06b1fe71-2ad8-4858-b27a-f66b2aa0d9df">
